### PR TITLE
adding promise to all the methods, just let the callback be undefined…

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ modem.setOwnNumber(number, callback)
 
 #### Execute AT Command
 ```js
-modem.executeCommand(callback, priority, timeout)
+modem.executeCommand(command, callback, priority, timeout)
 ```
 
 ## Other Usage 

--- a/lib/functions/modem.js
+++ b/lib/functions/modem.js
@@ -703,17 +703,19 @@ module.exports = function (SerialPort) {
               }
               returnResult = true
             }
-          } else if (modem.queue[0] && (modem.queue[0]['command'].substr(0, 2) == 'AT' )) { // the rest of commands
+          } else if (modem.queue[0] && (modem.queue[0]['command'].substr(0, 2) == 'ATH' )) { // hangup current call
             if ((newpart == ">" || newpart == 'OK')) {
               resultData = {
                 status: 'success',
-                request: modem.queue[0].command,
+                request: 'hangupCall',
+                data: newpart,
               }
               returnResult = true
             } else if (newpart == 'ERROR') {
               resultData = {
                 status: 'fail',
-                request: modem.queue[0].command,
+                request: 'hangupCall',
+                data: 'Cannot hangup call'
               }
               returnResult = true
             }
@@ -867,6 +869,23 @@ module.exports = function (SerialPort) {
       })
     }
     modem.executeCommand(`AT+CLIP=1`, result => {
+      callback(result)
+    }, false, timeout)
+  }
+
+  modem.hangupCall = (callback, timeout = 1000) => {
+    if (callback == undefined) {
+      return new Promise((resolve, reject) => {
+        modem.hangupCall((result, error) => {
+          if (error) {
+            reject(error)
+          } else {
+            resolve(result)
+          }
+        }, timeout)
+      })
+    }
+    modem.executeCommand(`ATH`, result => {
       callback(result)
     }, false, timeout)
   }

--- a/lib/functions/modem.js
+++ b/lib/functions/modem.js
@@ -703,6 +703,20 @@ module.exports = function (SerialPort) {
               }
               returnResult = true
             }
+          } else if (modem.queue[0] && (modem.queue[0]['command'].substr(0, 2) == 'AT' )) { // the rest of commands
+            if ((newpart == ">" || newpart == 'OK')) {
+              resultData = {
+                status: 'success',
+                request: modem.queue[0].command,
+              }
+              returnResult = true
+            } else if (newpart == 'ERROR') {
+              resultData = {
+                status: 'fail',
+                request: modem.queue[0].command,
+              }
+              returnResult = true
+            }
           }
           let callback
           if (returnResult) { // Expected Result was ok or with error call back function that asked for the data or emit to listener, Execute next Command if any or Execute Next Command if TIME Out and modem did not respond

--- a/lib/functions/modem.js
+++ b/lib/functions/modem.js
@@ -64,10 +64,10 @@ module.exports = function (SerialPort) {
     if (options && options.enableConcatenation == true) modem.enableConcatenation = true
     if (options && options.incomingCallIndication == true) modem.incomingCallIndication = true
     modem.port = SerialPort(device, options, (error) => {
-      let result = { status: 'success', request: 'connectModem', data: { modem: modem.port.path, status: 'Online' } }
       if (error) {
         callback(error)
       } else {
+        let result = { status: 'success', request: 'connectModem', data: { modem: modem.port.path, status: 'Online' } }
         modem.device = device
         modem.emit('open', result)
         callback(null, result)
@@ -98,31 +98,20 @@ module.exports = function (SerialPort) {
     })
   }
 
-  modem.readSMSById = function (id, callback) {
-    if (callback == undefined) {
-      return new Promise((resolve, reject) => {
-        modem.readSMSById((error, result) => {
-          if (error) {
-            reject(error)
-          } else {
-            resolve(result)
-          }
-        })
-      })
-    }
-    modem.executeCommand(`AT+CMGR=${id}`, function (result) { }, true)
+  modem.readSMSById = function (id) {
+    modem.executeCommand(`AT+CMGR=${id}`, undefined, true)
   }
 
   modem.checkSimMemory = function (callback, priority) {
     if (callback == undefined) {
       return new Promise((resolve, reject) => {
-        modem.checkSimMemory((error, result) => {
+        modem.checkSimMemory((result, error) => {
           if (error) {
             reject(error)
           } else {
             resolve(result)
           }
-        })
+        }, priority)
       })
     }
     if (priority == null) priority = false
@@ -134,13 +123,13 @@ module.exports = function (SerialPort) {
   modem.initializeModem = function (callback, priority) {
     if (callback == undefined) {
       return new Promise((resolve, reject) => {
-        modem.initializeModem((error, result) => {
+        modem.initializeModem((result, error) => {
           if (error) {
             reject(error)
           } else {
             resolve(result)
           }
-        })
+        }, priority)
       })
     }
     if (priority == null) priority = false
@@ -150,6 +139,17 @@ module.exports = function (SerialPort) {
   }
 
   modem.setModemMode = function (callback, priority, timeout, mode) {
+    if (callback == undefined) {
+      return new Promise((resolve, reject) => {
+        modem.setModemMode((result, error) => {
+          if (error) {
+            reject(error)
+          } else {
+            resolve(result)
+          }
+        }, priority, timeout, mode)
+      })
+    }
     if (priority == null) priority = true
     if (timeout == 'PDU' || timeout == 'SMS') {
       mode == timeout
@@ -184,6 +184,17 @@ module.exports = function (SerialPort) {
   }
 
   modem.sendSMS = function (number, message, alert = false, callback) {
+    if (callback == undefined) {
+      return new Promise((resolve, reject) => {
+        modem.sendSMS(number, message, alert, (result, error) => {
+          if (error) {
+            reject(error)
+          } else {
+            resolve(result)
+          }
+        })
+      })
+    }
     try {
       if (number && message) {
         let messageID = modem.makeId(25)
@@ -206,30 +217,35 @@ module.exports = function (SerialPort) {
               channel = 'onMessageSent'
             }
 
-            let result = {
-              status: data.status,
-              request: data.request,
-              data: {
-                messageId: data.data.messageId,
-                message: data.data.message,
-                recipient: data.data.recipient,
-                response: data.data.response
-              }
-            }
             if (i == parts.length - 1) {
+              const result = {
+                status: data.status,
+                request: data.request,
+                data: {
+                  messageId: data.data.messageId,
+                  message: data.data.message,
+                  recipient: data.data.recipient,
+                  response: data.data.response
+                }
+              }
               modem.emit(channel, result)
               callback(result)
             }
           }, false, 30000, messageID, message, number)
         }
-        callback({
-          status: 'success',
-          request: 'sendSMS',
-          data: {
-            messageId: messageID,
-            response: 'Successfully Sent to Message Queue'
-          }
-        })
+        // if it is called with promise (the promise callback has 2 args)
+        // it is better not to callback until the message is sent or failed, 
+        // the call back send above inside the call back
+        if(callback.length===1){
+          callback({
+            status: 'success',
+            request: 'sendSMS',
+            data: {
+              messageId: messageID,
+              response: 'Successfully Sent to Message Queue'
+            }
+          })
+        }
 
       } else {
         callback({
@@ -248,6 +264,17 @@ module.exports = function (SerialPort) {
   }
 
   modem.deleteAllSimMessages = function (callback, priority, timeout) {
+    if (callback == undefined) {
+      return new Promise((resolve, reject) => {
+        modem.deleteAllSimMessages((result, error) => {
+          if (error) {
+            reject(error)
+          } else {
+            resolve(result)
+          }
+        }, priority, timeout)
+      })
+    }
     if (priority == null) priority = false
     modem.executeCommand('AT+CMGD=1,4', function (result) {
       callback(result)
@@ -255,6 +282,17 @@ module.exports = function (SerialPort) {
   }
 
   modem.getModemSerial = function (callback, priority, timeout) {
+    if (callback == undefined) {
+      return new Promise((resolve, reject) => {
+        modem.getModemSerial((result, error) => {
+          if (error) {
+            reject(error)
+          } else {
+            resolve(result)
+          }
+        }, priority, timeout)
+      })
+    }
     if (priority == null) priority = false
     modem.executeCommand('AT+CGSN', function (result) {
       callback(result)
@@ -263,6 +301,17 @@ module.exports = function (SerialPort) {
   }
 
   modem.getNetworkSignal = function (callback, priority, timeout) {
+    if (callback == undefined) {
+      return new Promise((resolve, reject) => {
+        modem.getNetworkSignal((result, error) => {
+          if (error) {
+            reject(error)
+          } else {
+            resolve(result)
+          }
+        }, priority, timeout)
+      })
+    }
     if (priority == null) priority = false
     modem.executeCommand('AT+CSQ', function (result) {
       callback(result)
@@ -276,7 +325,18 @@ module.exports = function (SerialPort) {
     modem.queue.shift() //Remove current item from queue.
   }
 
-  modem.executeCommand = (command, c, priority, timeout, messageID, message, recipient) => {
+  modem.executeCommand = (command, callback, priority, timeout, messageID, message, recipient) => {
+    if (callback == undefined) {
+      return new Promise((resolve, reject) => {
+        modem.executeCommand(command, (result, error) => {
+          if (error) {
+            reject(error)
+          } else {
+            resolve(result)
+          }
+        }, priority, timeout, messageID, message, recipient)
+      })
+    }
     if (!modem.isOpened) {
       modem.emit('close')
       return
@@ -290,7 +350,7 @@ module.exports = function (SerialPort) {
       item.status = 'sendSMS'
     }
     item.command = command
-    item.callback = c
+    item.callback = callback
     item.add_time = new Date()
     item.id = ++modem.jobID
     item.timeout = timeout
@@ -353,10 +413,10 @@ module.exports = function (SerialPort) {
       newparts = part.split('\n')
       newparts.forEach(newpart => {
         let pduTest = /[0-9A-Fa-f]{15}/g
-        if (newpart.substr(0, 6) == '+CMTI:') { // New Message Indicatpr with SIM Card ID, After Recieving Read The Message From the SIM Card
+        if (newpart.substr(0, 6) == '+CMTI:') { // New Message Indicator with SIM Card ID, After Recieving Read The Message From the SIM Card
           newpart = newpart.split(',')
-          modem.readSMSById(newpart[1], res => { })
-        } else if (newpart.substr(0, 5) == '+CLIP') { // New Message Indicatpr with SIM Card ID, After Recieving Read The Message From the SIM Card
+          modem.readSMSById(newpart[1])
+        } else if (newpart.substr(0, 5) == '+CLIP') { // New Message Indicator with SIM Card ID, After Recieving Read The Message From the SIM Card
           newpart = newpart.split(',')
           if (modem.incomingCallIndication == true) {
             modem.emit('onNewIncomingCall', {
@@ -368,9 +428,7 @@ module.exports = function (SerialPort) {
             })
           }
         } else if (newpart.substr(0, 10) == '^SMMEMFULL' || newpart.indexOf('^SMMEMFULL') > -1) {
-          modem.checkSimMemory((err, res) => {
-
-          })
+          modem.checkSimMemory()
         }
         if (modem.queue.length) {
           if (modem.queue[0] && (modem.queue[0].status == 'sendSMS')) { // If SMS is currently Sending Emit currently sending SMS
@@ -511,9 +569,7 @@ module.exports = function (SerialPort) {
               if (modem.autoDeleteOnReceive == true) {
                 modem.deleteMessage(message)
               }
-              modem.checkSimMemory((err, res) => {
-
-              })
+              modem.checkSimMemory()
             }
             regx.lastIndex = 0 // be sure to reset the index after using .test()
             if ((newpart == ">" || newpart == 'OK') && resultData) {
@@ -700,49 +756,104 @@ module.exports = function (SerialPort) {
   }
 
   modem.getOwnNumber = (callback, timeout = 10000) => {
+    if (callback == undefined) {
+      return new Promise((resolve, reject) => {
+        modem.getOwnNumber((result, error) => {
+          if (error) {
+            reject(error)
+          } else {
+            resolve(result)
+          }
+        }, timeout)
+      })
+    }
     modem.executeCommand(`AT+CNUM`, result => {
       callback(result)
     }, false, timeout)
   }
 
   modem.setOwnNumber = (number, callback, name = 'OwnNumber', timeout = 10000) => {
+    if (callback == undefined) {
+      return new Promise((resolve, reject) => {
+        modem.setOwnNumber(number, (result, error) => {
+          if (error) {
+            reject(error)
+          } else {
+            resolve(result)
+          }
+        }, name, timeout)
+      })
+    }
     //Select Phonebook Memery Storage "ON" SIM (or ME) own numbers (MSISDNs) list (reading of this storage may be available through +CNUM
     modem.executeCommand(`AT+CPBS="ON"`, result => {
       if (result.data === 'OK') {
         //CPBW parameters, Phonebook location, phone number, type of address octet in integer format, name
         modem.executeCommand(`AT+CPBW=1,"${number}",129,"${name}"`, result => {
-          if (callback) callback(result)
+          callback(result)
         }, false, timeout)
       }
     }, false, timeout)
   }
 
   modem.getSimInbox = (callback, timeout = 15000) => {
+    if (callback == undefined) {
+      return new Promise((resolve, reject) => {
+        modem.getSimInbox((result, error) => {
+          if (error) {
+            reject(error)
+          } else {
+            resolve(result)
+          }
+        }, timeout)
+      })
+    }
     modem.executeCommand((modem.modemMode == 0 ? `AT+CMGL=4` : `AT+CMGL="ALL"`), result => {
       callback(result)
     }, false, timeout)
   }
 
   modem.deleteMessage = (message, callback, timeout = 10000) => {
+    if (callback == undefined) {
+      return new Promise((resolve, reject) => {
+        modem.deleteMessage(message, (result, error) => {
+          if (error) {
+            reject(error)
+          } else {
+            resolve(result)
+          }
+        }, timeout)
+      })
+    }
     if (modem.enableConcatenation == true && message.udhs) {
       let indexes = message.udhs.map(a => a.index).sort((a, b) => { return b - a })
       indexes.forEach((i, index) => {
         modem.executeCommand(`AT+CMGD=${i}`, result => {
           if (index == indexes.length - 1) {
-            if (callback) callback(result)
+            callback(result)
           }
         }, false, timeout)
       })
     } else {
       modem.executeCommand(`AT+CMGD=${message.index}`, result => {
-        if (callback) callback(result)
+        callback(result)
       }, false, timeout)
     }
   }
 
   modem.enableCLIP = (callback, timeout = 1000) => {
+    if (callback == undefined) {
+      return new Promise((resolve, reject) => {
+        modem.enableCLIP((result, error) => {
+          if (error) {
+            reject(error)
+          } else {
+            resolve(result)
+          }
+        }, timeout)
+      })
+    }
     modem.executeCommand(`AT+CLIP=1`, result => {
-      if (callback) callback(result)
+      callback(result)
     }, false, timeout)
   }
 

--- a/lib/functions/modem.js
+++ b/lib/functions/modem.js
@@ -414,16 +414,16 @@ module.exports = function (SerialPort) {
       newparts.forEach(newpart => {
         let pduTest = /[0-9A-Fa-f]{15}/g
         if (newpart.substr(0, 6) == '+CMTI:') { // New Message Indicator with SIM Card ID, After Recieving Read The Message From the SIM Card
-          newpart = newpart.split(',')
-          modem.readSMSById(newpart[1])
+          const splitted_newpart = newpart.split(',')
+          modem.readSMSById(splitted_newpart[1])
         } else if (newpart.substr(0, 5) == '+CLIP') { // New Message Indicator with SIM Card ID, After Recieving Read The Message From the SIM Card
-          newpart = newpart.split(',')
+          const splitted_newpart = newpart.split(',')
           if (modem.incomingCallIndication == true) {
             modem.emit('onNewIncomingCall', {
               status: 'Incoming Call',
               data: {
-                number: /\"(.*?)\"/g.exec(newpart[0])[1],
-                numberingScheme: newpart[1],
+                number: /\"(.*?)\"/g.exec(splitted_newpart[0])[1],
+                numberingScheme: splitted_newpart[1],
               }
             })
           }


### PR DESCRIPTION
- Adding promise to all the methods, just let the callback be undefined to return a promise.
- Code cleanup.
- README update on executeCommand function.
- checkSimMemory promise bug fix, the callback fires with only one argument, so the first one should be result and the second error, this let us to remove unnecessary callback definitions.
- readSMSBuId callback was never used, so it is removed.
- initializeModem promise bug fix, the callback is being fired with one argument, so the first one should be result.
- for open and close methods, I suggest to change the callback arguments order to be (result, error) in order to be like the others.
- If sendSMS method is in promise mode, fires callback only after the sms is sent or failed, but for the sake of backward compatibility it is fired 2 times if there is a callback function provided.
- as we provide a promise callback if it is undefined, there is no need to check it if the callback is present or not to fire it, it is always present.
