### PR TITLE
Moving the command execution logic to caller function

### DIFF
--- a/lib/functions/modem.js
+++ b/lib/functions/modem.js
@@ -439,8 +439,8 @@ module.exports = function (SerialPort) {
         } else if (newpart.substr(0, 10) == '^SMMEMFULL' || newpart.indexOf('^SMMEMFULL') > -1) {
           modem.checkSimMemory()
         }
-        if (modem.queue.length) {
-          if (modem.queue[0] && (modem.queue[0].status == 'sendSMS')) { // If SMS is currently Sending Emit currently sending SMS
+        if (modem.queue.length && modem.queue[0]) {
+          if ((modem.queue[0].status == 'sendSMS')) { // If SMS is currently Sending Emit currently sending SMS
             modem.emit('onSendingMessage', {
               status: 'Sending SMS',
               request: 'sendingSMS',
@@ -453,7 +453,7 @@ module.exports = function (SerialPort) {
             })
             modem.queue[0]['status'] = 'Sending SMS'
           }
-          if (modem.queue[0] && (modem.queue[0].command == `AT+CPMS="SM"`)) { // Query SIM Card Space Available
+          if ((modem.queue[0].command == `AT+CPMS="SM"`)) { // Query SIM Card Space Available
             if (newpart.trim().substr(0, 6) === '+CPMS:') {
               modem.parseSimCardResponse(newpart, result => {
                 resultData = result
@@ -462,7 +462,7 @@ module.exports = function (SerialPort) {
             if ((newpart == ">" || newpart == 'OK') && resultData) {
               returnResult = true
             }
-          } else if (modem.queue[0] && (modem.queue[0].command == 'AT+CMGD=1,4')) { // Delete All Data from SIM Card
+          } else if ((modem.queue[0].command == 'AT+CMGD=1,4')) { // Delete All Data from SIM Card
             if (newpart == 'OK') {
               resultData = {
                 status: 'success',
@@ -471,7 +471,7 @@ module.exports = function (SerialPort) {
               }
               returnResult = true
             }
-          } else if (modem.queue[0] && (modem.queue[0].command.substr(0, 7) == 'AT+CMGD')) { // Delete By Index from SIM Card
+          } else if ((modem.queue[0].command.substr(0, 7) == 'AT+CMGD')) { // Delete By Index from SIM Card
             if (newpart == 'OK') {
               resultData = {
                 status: 'success',
@@ -480,7 +480,7 @@ module.exports = function (SerialPort) {
               }
               returnResult = true
             }
-          } else if (modem.queue[0] && (modem.queue[0].command == 'ATZ')) { // Query Modem AT to initialize
+          } else if ((modem.queue[0].command == 'ATZ')) { // Query Modem AT to initialize
             resultData = {
               status: 'success',
               request: 'modemInitialized',
@@ -489,7 +489,7 @@ module.exports = function (SerialPort) {
             if ((newpart == ">" || newpart == "> " || newpart == 'OK') && resultData) {
               returnResult = true
             }
-          } else if (modem.queue[0] && (modem.queue[0].command == 'AT+CSQ')) { // Query Modem AT to initialize
+          } else if ((modem.queue[0].command == 'AT+CSQ')) { // Query Modem AT to initialize
 
             if (newpart.substr(0, 5) == '+CSQ:') {
               let signal = newpart.split(' ')
@@ -509,7 +509,7 @@ module.exports = function (SerialPort) {
                 data: 'Cannot Get Signal'
               }
             }
-          } else if (modem.queue[0] && (modem.queue[0].command == 'AT+CGSN')) { // Query Modem AT to initialize
+          } else if ((modem.queue[0].command == 'AT+CGSN')) { // Query Modem AT to initialize
             let isSerial = /^\d+$/.test(newpart)
             if (isSerial) {
               resultData = {
@@ -528,7 +528,7 @@ module.exports = function (SerialPort) {
               }
               returnResult = true
             }
-          } else if (modem.queue[0] && (modem.queue[0].command == 'AT+CMGF=0') || (modem.queue[0].command == 'AT+CMGF=1')) { // PDU Mode for Modem .. Default PDU Mode to accomodate Long SMS
+          } else if ((modem.queue[0].command == 'AT+CMGF=0') || (modem.queue[0].command == 'AT+CMGF=1')) { // PDU Mode for Modem .. Default PDU Mode to accomodate Long SMS
             if (modem.queue[0]['command'].substr(8, 8) == '0') {
               resultData = {
                 status: 'success',
@@ -545,7 +545,7 @@ module.exports = function (SerialPort) {
             if ((newpart == ">" || newpart == 'OK') && resultData) {
               returnResult = true
             }
-          } else if (modem.queue[0] && (modem.queue[0].command.substr(0, 7) == 'AT+CMGR')) { // Get New Message From SIM Card
+          } else if ((modem.queue[0].command.substr(0, 7) == 'AT+CMGR')) { // Get New Message From SIM Card
             let regx = /[0-9A-Fa-f]{15}/g
             if (regx.test(newpart)) {
               let newMessage = pdu.parse(newpart)
@@ -584,7 +584,7 @@ module.exports = function (SerialPort) {
             if ((newpart == ">" || newpart == 'OK') && resultData) {
               returnResult = true
             }
-          } else if (modem.queue[0] && (modem.queue[0].command.substr(0, 7) == 'AT+CNUM')) { //Get own number
+          } else if ((modem.queue[0].command.substr(0, 7) == 'AT+CNUM')) { //Get own number
             if (newpart.indexOf('+CNUM') > -1) {
               let splitResult = newpart.split(',')
               if (splitResult.length > 0 && splitResult[1]) {
@@ -609,7 +609,7 @@ module.exports = function (SerialPort) {
               }
               returnResult = true
             }
-          } else if (modem.queue[0] && (modem.queue[0].command.substr(0, 9) == 'AT+CLIP=1')) { // Enable Clip
+          } else if ((modem.queue[0].command.substr(0, 9) == 'AT+CLIP=1')) { // Enable Clip
             if (newpart == ">" || newpart == 'OK') {
               resultData = {
                 status: 'success',
@@ -625,7 +625,7 @@ module.exports = function (SerialPort) {
               }
               returnResult = true
             }
-          } else if (modem.queue[0] && (modem.queue[0].command.substr(0, 7) == 'AT+CPBS')) { // Select Phonebook
+          } else if ((modem.queue[0].command.substr(0, 7) == 'AT+CPBS')) { // Select Phonebook
             if (newpart == ">" || newpart == 'OK') {
               resultData = {
                 status: 'success',
@@ -641,7 +641,7 @@ module.exports = function (SerialPort) {
               }
               returnResult = true
             }
-          } else if (modem.queue[0] && (modem.queue[0].command.substr(0, 7) == 'AT+CPBW')) { // Write to Phonebook
+          } else if ((modem.queue[0].command.substr(0, 7) == 'AT+CPBW')) { // Write to Phonebook
             if (newpart == ">" || newpart == 'OK') {
               resultData = {
                 status: 'success',
@@ -657,7 +657,7 @@ module.exports = function (SerialPort) {
               }
               returnResult = true
             }
-          } else if (modem.queue[0] && (modem.queue[0].command.substr(0, 9) == 'AT+CMGL=4')) { // Get Sim Inbox
+          } else if ((modem.queue[0].command.substr(0, 9) == 'AT+CMGL=4')) { // Get Sim Inbox
             let regx = /[0-9A-Fa-f]{15}/g
             if (!resultData) {
               resultData = {
@@ -686,7 +686,7 @@ module.exports = function (SerialPort) {
               }
               returnResult = true
             }
-          } else if (modem.queue[0] && (modem.queue[0].command.substr(0, 7) == 'AT+CMGS' || pduTest.test(modem.queue[0].command))) { // Sending of Message if with response ok.. Then Message was sent successfully.. If Error then Message Sending Failed
+          } else if ((modem.queue[0].command.substr(0, 7) == 'AT+CMGS' || pduTest.test(modem.queue[0].command))) { // Sending of Message if with response ok.. Then Message was sent successfully.. If Error then Message Sending Failed
             resultData = {
               status: 'success',
               request: 'SendSMS',
@@ -712,21 +712,13 @@ module.exports = function (SerialPort) {
               }
               returnResult = true
             }
-          } else if (modem.queue[0] && (modem.queue[0].command.substr(0, 3) == 'ATH')) { // hangup current call
-            if ((newpart == ">" || newpart == 'OK')) {
-              resultData = {
-                status: 'success',
-                request: 'hangupCall',
-                data: newpart,
+          } else { // let's check if it has a logic function
+            if (modem.queue[0].logic){
+              const logicResult = modem.queue[0].logic(newpart);
+              if(logicResult){
+                resultData = logicResult.resultData
+                returnResult = logicResult.returnResult
               }
-              returnResult = true
-            } else if (newpart == 'ERROR') {
-              resultData = {
-                status: 'fail',
-                request: 'hangupCall',
-                data: 'Cannot hangup call'
-              }
-              returnResult = true
             }
           }
           let callback
@@ -901,9 +893,31 @@ module.exports = function (SerialPort) {
         }, timeout)
       })
     }
-    modem.executeCommand(`ATH`, (result, error) => {
+    const item = modem.executeCommand(`ATH`, (result, error) => {
       callback(result, error)
     }, false, timeout)
+    item.logic = (newpart) => {
+      console.log(`logic for command : ${item.command} with newpart : ${newpart}`)
+      if ((newpart == ">" || newpart == 'OK')) {
+        return {
+          resultData: {
+            status: 'success',
+            request: 'hangupCall',
+            data: newpart,
+          },
+          returnResult: true,
+        }
+      } else if (newpart == 'ERROR') {
+        return {
+          resultData: {
+            status: 'fail',
+            request: 'hangupCall',
+            data: 'Cannot hangup call'
+          },
+          returnResult: true,
+        }
+      }
+    }
   }
 
   self.processMessage = (message, messageIndex) => {


### PR DESCRIPTION
Here the idea is to have the response processing logic close to the caller function. In order to be coordinate the refactoring with you I refactored one function for sample. Please check and tell me if we can do it for the rest of the commands.

Please read the changes done in lines 715 and 899. The idea is to add a `logic` function after we run `executeCommand` (line 899) which returns the `item` added to execution queue. This function will be executed in line 715 on the `dataReceived` function. As we are attaching the `logic` function to the `item` in the queue, this type of checking `modem.queue[0].command.substr(0, 3) == 'ATH'` is not needed any more.

This way adding a new command is easier and also possible for the consumer out of the repo.

SMS sending and receiving is a bit different, I suggest to not refactor them at the moment. 

Please tell me you opinion and if you agree I refactor the rest of the commands (except send / receive SMS).

Beside, I do not have a possibility to check all of the commands, do you have that opportunity to test all of them after I refactored?