### PR TITLE
Fixes, Style stuff and Feature enhancements:

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,13 @@ modem.on('open', data => {
 })	
 ```
 
+#### Check Modem Communication
+Send simple command to check communication with device
+```js
+modem.checkModem(callback)
+```
+
+
 #### Send Message
 Sends sms.
 `sendSMS(recipient, message, alert, callback)`

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Sends sms.
  * `alert` - parameter is boolean
     * `true` - send as class 0 message(flash message)
     * `false` - send as a normal sms
- * callback
+ * `callback` - the callback is called twice! First time when queued for sending and second time when message was really send out!
 ```js
 modem.sendSMS('63999XXXXX19', 'Hello there Zab!', true, callback)
 ```

--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ When opening a serial port, specify (in this order)
     * `autoDeleteOnReceive` - Set to `true` to delete from sim after receiving | Default is `false`
     * `enableConcatenation` - Set to `true` to receive concatenated messages as one | Default is `false`
     * `incomingCallIndication` - Set to `true` to fire the `onNewIncomingCall` event when receiving calls | Default is `false`
+    * `incomingSMSIndication` - Set to `false` to not fire the `onNewIncomingCall` event when receiving calls | Default is `true`
+    * `pin` - If your SIM card is protected by a IN provide the PIN as String and it will be used to unlock the SIM card during initialization | Default is `` (empty, means "no PIN existing on the SIM card")
+    * `customInitCommand` - If your device needs a custom initialization command it can be provided and will be used after PIN check. The command is expected to return "OK" | Default is `` (empty, means "no custom command for init")
+    * `logger` - provide a logger instance, currently "debug" is used only to output written and received serial data. Use "console" for debugging purposes | Default is no logging
 ```js
 let serialportgsm = require('serialport-gsm')
 let modem = serialportgsm.Modem()
@@ -80,7 +84,11 @@ let options = {
     xany: false,
     autoDeleteOnReceive: true,
     enableConcatenation: true,
-    incomingCallIndication: true
+    incomingCallIndication: true,
+    incomingSMSIndication: true,
+    pin: '',
+    customInitCommand: '',
+    logger: console
 }
 
 modem.open('COM', options, callback[Optional])

--- a/lib/functions/modem.js
+++ b/lib/functions/modem.js
@@ -19,9 +19,15 @@ module.exports = function (SerialPort) {
   modem.modemMode = 0
   modem.tempConcatenatedMessages = {}
   modem.device = ''
+  modem.pin = ''
+  modem.customInitCommand = ''
+  modem.incomingSMSIndication = true
+  modem.logger = {
+    debug: function() {}
+  };
 
   modem.close = function (callback) {
-    if (callback == undefined) {
+    if (typeof callback !== 'function') {
       return new Promise((resolve, reject) => {
         modem.close((error, result) => {
           if (error) {
@@ -49,7 +55,7 @@ module.exports = function (SerialPort) {
   }
 
   modem.open = function (device, options, callback) {
-    if (callback == undefined) {
+    if (typeof callback !== 'function') {
       return new Promise((resolve, reject) => {
         modem.open(device, options, (error, result) => {
           if (error) {
@@ -61,9 +67,13 @@ module.exports = function (SerialPort) {
       })
     }
     if (options) options['parser'] = SerialPort.parsers.raw
-    if (options && options.autoDeleteOnReceive == true) modem.autoDeleteOnReceive = true
-    if (options && options.enableConcatenation == true) modem.enableConcatenation = true
-    if (options && options.incomingCallIndication == true) modem.incomingCallIndication = true
+    if (options && options.autoDeleteOnReceive !== undefined) modem.autoDeleteOnReceive = options.autoDeleteOnReceive
+    if (options && options.enableConcatenation !== undefined) modem.enableConcatenation = options.enableConcatenation
+    if (options && options.incomingCallIndication !== undefined) modem.incomingCallIndication = options.incomingCallIndication
+    if (options && options.incomingSMSIndication !== undefined) modem.incomingSMSIndication = options.incomingSMSIndication
+    if (options && options.pin && options.pin.length) modem.pin = options.pin
+    if (options && options.customInitCommand && options.customInitCommand.length) modem.customInitCommand = options.customInitCommand
+    if (options && options.logger) modem.logger = options.logger
     modem.port = SerialPort(device, options, (error) => {
       if (error) {
         callback(error)
@@ -72,9 +82,6 @@ module.exports = function (SerialPort) {
         modem.device = device
         modem.emit('open', result)
         callback(null, result)
-        if (modem.incomingCallIndication == true) {
-          modem.enableCLIP(()=>{}) // we are not interested in the call back
-        }
       }
     })
 
@@ -111,6 +118,7 @@ module.exports = function (SerialPort) {
 
   modem.readSMSById = function (id) {
     const item = modem.executeCommand(`AT+CMGR=${id}`, ()=>{}, true)
+
     let resultData;
     item.logic = (newpart) => {
       let regx = /[0-9A-Fa-f]{15}/g
@@ -124,7 +132,7 @@ module.exports = function (SerialPort) {
         }
         let message = self.processMessage(newMessage, messageIndex)
 
-        if (modem.enableConcatenation == true && message.udh) {
+        if (modem.enableConcatenation && message.udh) {
           if (modem.tempConcatenatedMessages[message.udh.referenceNumber]) {
             modem.tempConcatenatedMessages[message.udh.referenceNumber].push(message)
           } else {
@@ -132,7 +140,7 @@ module.exports = function (SerialPort) {
           }
           let tempMessage = self.arrangeMessages(modem.tempConcatenatedMessages[message.udh.referenceNumber])[0]
           //check if complete
-          if (tempMessage.udh.parts == tempMessage.udhs.length) {
+          if (tempMessage.udh.parts === tempMessage.udhs.length) {
             delete modem.tempConcatenatedMessages[message.udh.referenceNumber]
             modem.emit('onNewMessageIndicator', resultData)
             modem.emit('onNewMessage', tempMessage)
@@ -142,13 +150,13 @@ module.exports = function (SerialPort) {
           modem.emit('onNewMessage', message)
         }
 
-        if (modem.autoDeleteOnReceive == true) {
+        if (modem.autoDeleteOnReceive) {
           modem.deleteMessage(message)
         }
         modem.checkSimMemory()
       }
       regx.lastIndex = 0 // be sure to reset the index after using .test()
-      if ((newpart == ">" || newpart == 'OK') && resultData) {
+      if ((newpart === '>' || newpart === 'OK') && resultData) {
         return {
           resultData,
           returnResult: true,
@@ -158,7 +166,7 @@ module.exports = function (SerialPort) {
   }
 
   modem.checkSimMemory = function (callback, priority) {
-    if (callback == undefined) {
+    if (typeof callback !== 'function') {
       return new Promise((resolve, reject) => {
         modem.checkSimMemory((result, error) => {
           if (error) {
@@ -170,17 +178,17 @@ module.exports = function (SerialPort) {
       })
     }
     if (priority == null) priority = false
-    const item = modem.executeCommand(`AT+CPMS="SM"`, function (result, error) {
+    const item = modem.executeCommand(`AT+CPMS="SM"`, (result, error) => {
       callback(result, error)
     }, priority)
     item.logic = (newpart) => {
       let resultData;
-      if (newpart.trim().substr(0, 6) === '+CPMS:') {
+      if (newpart.trim().startsWith('+CPMS:')) {
         modem.parseSimCardResponse(newpart, result => {
           resultData = result
         })
       }
-      //(newpart == ">" || newpart == 'OK') && 
+      //(newpart === '>' || newpart === 'OK') &&
       if (resultData) {
         return {
           resultData,
@@ -191,7 +199,67 @@ module.exports = function (SerialPort) {
   }
 
   modem.initializeModem = function (callback, priority, timeout) {
-    if (callback == undefined) {
+
+    function sendAdditionalCommands() {
+      const item = modem.executeCommand('AT+CMEE=1;+CREG=2', (result, error) => {
+        // we do not need the callback
+      }, false, timeout || 30000)
+      item.logic = (newpart) => {
+        if (newpart === '>' || newpart === '> ' || newpart === 'OK') {
+          return {
+            resultData: {
+              status: 'success',
+              request: 'modemInitialized',
+              data: 'Modem Successfully Initialized'
+            },
+            returnResult: true,
+          }
+        } else if (newpart.includes('ERROR')) {
+          return {
+            resultData: {
+              status: 'ERROR',
+              request: 'initializeModem',
+              data: `Cannot Get Modem Initialized ${newpart}`
+            },
+            returnResult: true,
+          }
+        }
+      }
+
+      if (modem.customInitCommand.length) {
+        const item = modem.executeCommand(modem.customInitCommand, (result, error) => {
+          // we do not need the callback
+        }, false, timeout || 30000)
+        item.logic = (newpart) => {
+          if (newpart === '>' || newpart === '> ' || newpart === 'OK') {
+            return {
+              resultData: {
+                status: 'success',
+                request: 'modemInitialized',
+                data: 'Modem Successfully Initialized'
+              },
+              returnResult: true,
+            }
+          } else if (newpart.includes('ERROR')) {
+            return {
+              resultData: {
+                status: 'ERROR',
+                request: 'initializeModem',
+                data: `Cannot Get Modem Initialized ${newpart}`
+              },
+              returnResult: true,
+            }
+          }
+        }
+
+      }
+
+      if (modem.incomingCallIndication) {
+        modem.enableCLIP(() => {})
+      }
+    }
+
+    if (typeof callback !== 'function') {
       return new Promise((resolve, reject) => {
         modem.initializeModem((result, error) => {
           if (error) {
@@ -203,11 +271,48 @@ module.exports = function (SerialPort) {
       })
     }
     if (priority == null) priority = false
-    const item = modem.executeCommand('ATZ', function (result, error) {
-      callback(result, error)
+    modem.checkModem((resultCheck, error) => {
+      if (!error) {
+        modem.checkPINRequired((result, error) => {
+          if (!error && result.data.pinNeeded && modem.pin.length) {
+            modem.providePIN(modem.pin, (result, error) => {
+              if (!error) {
+                sendAdditionalCommands()
+              }
+              callback(resultCheck, error)
+            })
+          } else {
+            if (!error) {
+              sendAdditionalCommands()
+            }
+            callback(resultCheck, error)
+          }
+        })
+      } else {
+        callback(resultCheck, error)
+      }
+    });
+  }
+
+  modem.checkModem = function (callback, priority, timeout) {
+    if (typeof callback !== 'function') {
+      return new Promise((resolve, reject) => {
+        modem.checkModem((result, error) => {
+          if (error) {
+            reject(error)
+          } else {
+            resolve(result)
+          }
+        }, priority, timeout)
+      })
+    }
+    if (priority == null) priority = false
+    // is the modem Ready?
+    const item = modem.executeCommand('ATZ', (resultInit, error) => {
+      callback(resultInit, error)
     }, false, timeout || 30000)
     item.logic = (newpart) => {
-      if (newpart == ">" || newpart == "> " || newpart == 'OK') {
+      if (newpart === '>' || newpart === '> ' || newpart === 'OK') {
         return {
           resultData: {
             status: 'success',
@@ -216,12 +321,12 @@ module.exports = function (SerialPort) {
           },
           returnResult: true,
         }
-      }else if (newpart == 'ERROR') {
+      }else if (newpart.includes('ERROR')) {
         return {
           resultData: {
             status: 'ERROR',
             request: 'initializeModem',
-            data: 'Cannot Get Modem Initialized'
+            data: `Cannot Get Modem Initialized ${newpart}`
           },
           returnResult: true,
         }
@@ -233,7 +338,7 @@ module.exports = function (SerialPort) {
     if(callback !== undefined && typeof callback !== 'function') {
       return modem.setModemMode(undefined, callback, priority, timeout, mode)
     }
-    if (callback == undefined || typeof callback !== 'function') {
+    if (typeof callback !== 'function' || typeof callback !== 'function') {
       return new Promise((resolve, reject) => {
         modem.setModemMode((result, error) => {
           if (error) {
@@ -245,23 +350,28 @@ module.exports = function (SerialPort) {
       })
     }
     if (priority == null) priority = true
-    if (timeout == 'PDU' || timeout == 'SMS') {
-      mode == timeout
+    if (timeout === 'PDU' || timeout === 'SMS') {
+      mode = timeout
     }
-    if (priority == 'PDU' || priority == 'SMS') {
+    if (priority === 'PDU' || priority === 'SMS') {
       mode = priority
     }
-    if (mode == 'PDU' || mode == 'SMS') {
-      if (mode == 'PDU') {
+    if (mode === 'PDU' || mode === 'SMS') {
+      if (mode === 'PDU') {
         modem.modemMode = 0
-      } else if (mode = 'SMS') {
+      } else if (mode === 'SMS') {
         modem.modemMode = 1
       }
-      const item = modem.executeCommand(`AT+CMGF=${modem.modemMode}`, function (result, error) {
+      const item = modem.executeCommand(`AT+CMGF=${modem.modemMode}`, (result, error) => {
+        if (mode === 'PDU' && !error && modem.incomingSMSIndication) {
+          modem.enableCNMI(() => {})
+        }
+
         callback(result, error)
       }, false, 30000)
+
+      let resultData;
       item.logic = (newpart) => {
-        let resultData;
         if (modem.modemMode === 0) {
           resultData = {
             status: 'success',
@@ -275,7 +385,7 @@ module.exports = function (SerialPort) {
             data: 'SMS_Mode'
           }
         }
-        if ((newpart == ">" || newpart == 'OK') && resultData) {
+        if ((newpart === '>' || newpart === 'OK') && resultData) {
           return {
             resultData,
             returnResult: true,
@@ -300,7 +410,7 @@ module.exports = function (SerialPort) {
   }
 
   modem.sendSMS = function (number, message, alert = false, callback) {
-    if (callback == undefined) {
+    if (typeof callback !== 'function') {
       return new Promise((resolve, reject) => {
         modem.sendSMS(number, message, alert, (result, error) => {
           if (error) {
@@ -318,26 +428,26 @@ module.exports = function (SerialPort) {
         let submit = pdu.Submit()
         submit.setAddress(number)
         submit.setData(message)
-        if (alert == true) {
+        if (alert) {
           submit.getDcs().setUseMessageClass(alert)
         }
         let parts = submit.getParts()
 
         for (let i = 0; i < parts.length; i++) {
-          modem.executeCommand(`AT+CMGS=${(parts[i].toString().length / 2) - 1}`, function (data) { }, false, 100)
+          modem.executeCommand(`AT+CMGS=${(parts[i].toString().length / 2) - 1}`, (data) => { }, false, 100)
           modem.executeCommand(`${parts[i].toString()}` + '\x1a', function (data, error) {
             if(!data){
               // console.log('no data for sms send', {data, error})
               return
             }
             let channel = ''
-            if (data.status == 'fail') {
+            if (data.status === 'fail') {
               channel = 'onMessageSendingFailed'
             } else {
               channel = 'onMessageSent'
             }
 
-            if (i == parts.length - 1) {
+            if (i === parts.length - 1) {
               const result = {
                 status: data.status,
                 request: data.request,
@@ -383,8 +493,91 @@ module.exports = function (SerialPort) {
     }
   }
 
+  modem.checkPINRequired = function (callback, priority, timeout) {
+    if (typeof callback !== 'function') {
+      return new Promise((resolve, reject) => {
+        modem.checkPINRequired((result, error) => {
+          if (error) {
+            reject(error)
+          } else {
+            resolve(result)
+          }
+        }, priority, timeout)
+      })
+    }
+    if (priority == null) priority = false
+    const item = modem.executeCommand('AT+CPIN?', (result, error) => {
+      callback(result, error)
+    }, priority, timeout)
+
+    let resultData
+    item.logic = (newpart) => {
+      if (newpart.startsWith('+CPIN: ')) {
+        resultData = {
+          status: 'success',
+          request: 'checkPINRequired',
+          data: {pinNeeded: !newpart.includes('READY')}
+        }
+      }
+      if (newpart.includes('OK') && resultData) {
+        return {
+          resultData,
+          returnResult: true
+        }
+      } else if (newpart.includes('ERROR')) {
+        return {
+          resultData: {
+            status: 'Error',
+            request: 'checkPINRequired',
+            error: newpart
+          },
+          returnResult: true
+        }
+      }
+    }
+  }
+
+  modem.providePIN = function (pin, callback, priority, timeout) {
+    if (typeof callback !== 'function') {
+      return new Promise((resolve, reject) => {
+        modem.providePIN(pin,(result, error) => {
+          if (error) {
+            reject(error)
+          } else {
+            resolve(result)
+          }
+        }, priority, timeout)
+      })
+    }
+    if (priority == null) priority = false
+    const item = modem.executeCommand(`AT+CPIN=${pin}`, (result, error) => {
+      callback(result, error)
+    }, priority, timeout)
+    item.logic = (newpart) => {
+      if (newpart.includes('ERROR')) {
+        return {
+          resultData: {
+            status: 'Error',
+            request: 'providePIN',
+            error: newpart
+          },
+          returnResult: true
+        }
+      } else {
+        return {
+          resultData: {
+            status: 'success',
+            request: 'providePIN',
+            data: 'success'
+          },
+          returnResult: true
+        }
+      }
+    }
+  }
+
   modem.deleteAllSimMessages = function (callback, priority, timeout) {
-    if (callback == undefined) {
+    if (typeof callback !== 'function') {
       return new Promise((resolve, reject) => {
         modem.deleteAllSimMessages((result, error) => {
           if (error) {
@@ -396,11 +589,11 @@ module.exports = function (SerialPort) {
       })
     }
     if (priority == null) priority = false
-    const item = modem.executeCommand('AT+CMGD=1,4', function (result, error) {
+    const item = modem.executeCommand('AT+CMGD=1,4', (result, error) => {
       callback(result, error)
     }, priority, timeout)
     item.logic = (newpart) => {
-      if (newpart == 'OK') {
+      if (newpart === 'OK') {
         return {
           resultData: {
             status: 'success',
@@ -414,7 +607,7 @@ module.exports = function (SerialPort) {
   }
 
   modem.deleteSimMessages = function (id, callback, priority, timeout) {
-    if (callback == undefined) {
+    if (typeof callback !== 'function') {
       return new Promise((resolve, reject) => {
         modem.deleteSimMessages(id, (result, error) => {
           if (error) {
@@ -426,11 +619,11 @@ module.exports = function (SerialPort) {
       })
     }
     if (priority == null) priority = false
-    const item = modem.executeCommand(`AT+CMGD=${id}`, function (result, error) {
+    const item = modem.executeCommand(`AT+CMGD=${id}`, (result, error) => {
       callback(result, error)
     }, priority, timeout)
     item.logic = (newpart) => {
-      if (newpart == 'OK') {
+      if (newpart === 'OK') {
         return {
           resultData: {
             status: 'success',
@@ -444,7 +637,7 @@ module.exports = function (SerialPort) {
   }
 
   modem.getModemSerial = function (callback, priority, timeout) {
-    if (callback == undefined) {
+    if (typeof callback !== 'function') {
       return new Promise((resolve, reject) => {
         modem.getModemSerial((result, error) => {
           if (error) {
@@ -456,12 +649,13 @@ module.exports = function (SerialPort) {
       })
     }
     if (priority == null) priority = false
-    const item = modem.executeCommand('AT+CGSN', function (result, error) {
+    const item = modem.executeCommand('AT+CGSN', (result, error) => {
       callback(result, error)
     }, priority, timeout)
+
+    let resultData;
     item.logic = (newpart) => {
       let isSerial = /^\d+$/.test(newpart)
-      let resultData;
       if (isSerial) {
         resultData = {
           status: 'success',
@@ -469,17 +663,17 @@ module.exports = function (SerialPort) {
           data: { 'modemSerial': newpart }
         }
       }
-      if ((newpart == ">" || newpart == "> " || newpart == 'OK') && resultData) {
+      if ((newpart === '>' || newpart === '> ' || newpart === 'OK') && resultData) {
         return {
           resultData,
           returnResult: true,
         }
-      } else if (newpart == 'ERROR') {
+      } else if (newpart.includes('ERROR')) {
         return {
           resultData: {
             status: 'ERROR',
             request: 'getModemSerial',
-            data: 'Cannot Get Modem Serial Number'
+            data: `Cannot Get Modem Serial Number ${newpart}`
           },
           returnResult: true,
         }
@@ -488,7 +682,7 @@ module.exports = function (SerialPort) {
   }
 
   modem.getNetworkSignal = function (callback, priority, timeout) {
-    if (callback == undefined) {
+    if (typeof callback !== 'function') {
       return new Promise((resolve, reject) => {
         modem.getNetworkSignal((result, error) => {
           if (error) {
@@ -500,31 +694,34 @@ module.exports = function (SerialPort) {
       })
     }
     if (priority == null) priority = false
-    const item = modem.executeCommand('AT+CSQ', function (result, error) {
+    const item = modem.executeCommand('AT+CSQ', (result, error) => {
       callback(result, error)
     }, priority, timeout)
+
+    let resultData;
     item.logic = (newpart) => {
-      let resultData;
-      if (newpart.substr(0, 5) == '+CSQ:') {
+      if (newpart.startsWith('+CSQ:')) {
         let signal = newpart.split(' ')
         signal = signal[1].split(',')
         resultData = {
           status: 'success',
           request: 'getNetworkSignal',
-          data: { 'signalQuality': signal[0] }
+          data: {
+            'signalQuality': signal[0],
+            'signalStrength': signal[0] !== 99 ? (113 - signal[0] * 2) : undefined }
         }
       }
-      if ((newpart == ">" || newpart == "> " || newpart == 'OK') && resultData) {
+      if ((newpart === '>' || newpart === '> ' || newpart === 'OK') && resultData) {
         return {
           resultData,
           returnResult: true,
         }
-      } else if (newpart == "ERROR") {
+      } else if (newpart.includes('ERROR')) {
         return {
           resultData: {
             status: 'ERROR',
             request: 'getNetworkSignal',
-            data: 'Cannot Get Signal'
+            data: `Cannot Get Signal ${newpart}`
           },
           returnResult: true,
         }
@@ -539,7 +736,7 @@ module.exports = function (SerialPort) {
   }
 
   modem.executeCommand = (command, callback, priority, timeout, messageID, message, recipient) => {
-    if (callback == undefined) {
+    if (typeof callback !== 'function') {
       return new Promise((resolve, reject) => {
         modem.executeCommand(command, (result, error) => {
           if (error) {
@@ -619,6 +816,7 @@ module.exports = function (SerialPort) {
         modem.executeNext()
       }, item.timeout)
     modem.port.write(`${item.command}\r`)
+    modem.logger.debug(`Modem Write: ${item.command}`)
   }
 
   modem.dataReceived = buffer => {
@@ -628,30 +826,27 @@ module.exports = function (SerialPort) {
     let parts = data.split('\r\n')
     data = parts.pop()
     parts.forEach(part => {
-      let newparts = []
-      newparts = part.split('\r')
-      newparts = part.split('\n')
+      let newparts = part.split(/\r\n|\n|\r/)
       newparts.forEach(newpart => {
+        modem.logger.debug(`Modem Received: ${newpart}`)
         let pduTest = /[0-9A-Fa-f]{15}/g
-        if (newpart.substr(0, 6) == '+CMTI:') { // New Message Indicator with SIM Card ID, After Recieving Read The Message From the SIM Card
+        if (modem.incomingSMSIndication && newpart.startsWith('+CMTI:')) { // New Message Indicator with SIM Card ID, After Recieving Read The Message From the SIM Card
           const splitted_newpart = newpart.split(',')
           modem.readSMSById(splitted_newpart[1])
-        } else if (newpart.substr(0, 5) == '+CLIP') { // New Incomming call
+        } else if (modem.incomingCallIndication && newpart.startsWith('+CLIP')) { // New Incomming call
           const splitted_newpart = newpart.split(',')
-          if (modem.incomingCallIndication == true) {
-            modem.emit('onNewIncomingCall', {
-              status: 'Incoming Call',
-              data: {
-                number: /\"(.*?)\"/g.exec(splitted_newpart[0])[1],
-                numberingScheme: splitted_newpart[1],
-              }
-            })
-          }
-        } else if (newpart.substr(0, 10) == '^SMMEMFULL' || newpart.indexOf('^SMMEMFULL') > -1) {
+          modem.emit('onNewIncomingCall', {
+            status: 'Incoming Call',
+            data: {
+              number: /"(.*?)"/g.exec(splitted_newpart[0])[1],
+              numberingScheme: splitted_newpart[1],
+            }
+          })
+        } else if (newpart.includes('^SMMEMFULL')) {
           modem.checkSimMemory()
         }
 
-        //we can also move the logic of incomming call and incomming message here
+        //we can also move the logic of incoming call and incoming message here
         modem.listeners.forEach( l => {
           if(l.match(newpart)){
             l.process(newpart);
@@ -659,7 +854,7 @@ module.exports = function (SerialPort) {
         })
 
         if (modem.queue.length && modem.queue[0]) {
-          if ((modem.queue[0].status == 'sendSMS')) { // If SMS is currently Sending Emit currently sending SMS
+          if ((modem.queue[0].status === 'sendSMS')) { // If SMS is currently Sending Emit currently sending SMS
             modem.emit('onSendingMessage', {
               status: 'Sending SMS',
               request: 'sendingSMS',
@@ -672,7 +867,7 @@ module.exports = function (SerialPort) {
             })
             modem.queue[0]['status'] = 'Sending SMS'
           }
-          if ((modem.queue[0].command.substr(0, 7) == 'AT+CMGS' || pduTest.test(modem.queue[0].command))) { // Sending of Message if with response ok.. Then Message was sent successfully.. If Error then Message Sending Failed
+          if ((modem.queue[0].command.startsWith('AT+CMGS') || pduTest.test(modem.queue[0].command))) { // Sending of Message if with response ok.. Then Message was sent successfully.. If Error then Message Sending Failed
             resultData = {
               status: 'success',
               request: 'SendSMS',
@@ -683,9 +878,9 @@ module.exports = function (SerialPort) {
                 response: 'Message Successfully Sent'
               }
             }
-            if ((newpart == ">" || newpart == 'OK') && resultData) {
+            if ((newpart === '>' || newpart === 'OK') && resultData) {
               returnResult = true
-            } else if (newpart == 'ERROR') {
+            } else if (newpart.includes('ERROR')) {
               resultData = {
                 status: 'fail',
                 request: 'SendSMS',
@@ -693,7 +888,7 @@ module.exports = function (SerialPort) {
                   messageId: modem.queue[0].messageID,
                   message: modem.queue[0].message,
                   recipient: modem.queue[0].recipient,
-                  response: 'Message Failed'
+                  response: `Message Failed ${newpart}`
                 }
               }
               returnResult = true
@@ -742,7 +937,7 @@ module.exports = function (SerialPort) {
     newpart = newpart[1].split(',')
     simCardCheck.used = parseInt(newpart[0])
     simCardCheck.total = parseInt(newpart[1])
-    if (simCardCheck.used == simCardCheck.total) {
+    if (simCardCheck.used === simCardCheck.total) {
       modem.emit('onMemoryFull', {
         status: 'Memory Full',
         data: {
@@ -761,7 +956,7 @@ module.exports = function (SerialPort) {
   }
 
   modem.getOwnNumber = (callback, timeout = 10000) => {
-    if (callback == undefined) {
+    if (typeof callback !== 'function') {
       return new Promise((resolve, reject) => {
         modem.getOwnNumber((result, error) => {
           if (error) {
@@ -775,34 +970,35 @@ module.exports = function (SerialPort) {
     const item = modem.executeCommand(`AT+CNUM`, (result, error) => {
       callback(result, error)
     }, false, timeout)
+
     let resultData;
     item.logic = (newpart) => {
-      if (newpart.indexOf('+CNUM') > -1) {
+      if (newpart.startsWith('+CNUM')) {
         let splitResult = newpart.split(',')
         if (splitResult.length > 0 && splitResult[1]) {
           resultData = {
             status: 'success',
             request: 'getOwnNumber',
             data: {
-              name: /\"(.*?)\"/g.exec(splitResult[0])[1],
-              number: /\"(.*?)\"/g.exec(splitResult[1])[1]
+              name: /"(.*?)"/g.exec(splitResult[0])[1],
+              number: /"(.*?)"/g.exec(splitResult[1])[1]
             }
           }
         } else {
           // TODO what will happen here?
-          newpart == 'ERROR'
+          newpart === 'ERROR'
         }
-      } else if ((newpart == ">" || newpart == 'OK') && resultData) {
+      } else if ((newpart === '>' || newpart === 'OK') && resultData) {
         return {
           resultData,
           returnResult: true
         }
-      } else if (newpart == 'ERROR') {
+      } else if (newpart.includes('ERROR')) {
         return {
           resultData: {
             status: 'ERROR',
             request: 'getOwnNumber',
-            data: 'Cannot Get Sim Number'
+            data: `Cannot Get Sim Number ${newpart}`
           },
           returnResult: true
         }
@@ -811,7 +1007,7 @@ module.exports = function (SerialPort) {
   }
 
   modem.selectPhonebookStorage = (memory, callback, timeout = 10000) => {
-    if (callback == undefined) {
+    if (typeof callback !== 'function') {
       return new Promise((resolve, reject) => {
         modem.selectPhonebookStorage(memory, (result, error) => {
           if (error) {
@@ -827,7 +1023,7 @@ module.exports = function (SerialPort) {
       callback(result, error)
     }, false, timeout);
     item.logic = (newpart) => {
-      if (newpart == ">" || newpart == 'OK') {
+      if (newpart === '>' || newpart === 'OK') {
         return {
           resultData: {
             status: 'success',
@@ -836,12 +1032,12 @@ module.exports = function (SerialPort) {
           },
           returnResult: true,
         }
-      } else if (newpart == 'ERROR') {
+      } else if (newpart.includes('ERROR')) {
         return {
           resultData: {
             status: 'ERROR',
             request: 'selectPhonebookStorage',
-            data: 'Error on setting phonebook storage'
+            data: `Error on setting phonebook storage ${newpart}`
           },
           returnResult: true,
         }
@@ -850,7 +1046,7 @@ module.exports = function (SerialPort) {
   }
 
   modem.writeToPhonebook = (number, name, callback, timeout = 10000) => {
-    if (callback == undefined) {
+    if (typeof callback !== 'function') {
       return new Promise((resolve, reject) => {
         modem.writeToPhonebook(number, name, (result, error) => {
           if (error) {
@@ -866,7 +1062,7 @@ module.exports = function (SerialPort) {
       callback(result, error)
     }, false, timeout);
     item.logic = (newpart) => {
-      if (newpart == ">" || newpart == 'OK') {
+      if (newpart === '>' || newpart === 'OK') {
         return {
           resultData: {
             status: 'success',
@@ -875,12 +1071,12 @@ module.exports = function (SerialPort) {
           },
           returnResult: true,
         }
-      } else if (newpart == 'ERROR') {
+      } else if (newpart.includes('ERROR')) {
         return {
           resultData: {
             status: 'ERROR',
             request: 'writeToPhonebook',
-            data: 'Cannot Write To Phonebook'
+            data: `Cannot Write To Phonebook ${newpart}`
           },
           returnResult: true,
         }
@@ -889,7 +1085,7 @@ module.exports = function (SerialPort) {
   }
 
   modem.setOwnNumber = (number, callback, name = 'OwnNumber', timeout = 10000) => {
-    if (callback == undefined) {
+    if (typeof callback !== 'function') {
       return new Promise((resolve, reject) => {
         modem.setOwnNumber(number, (result, error) => {
           if (error) {
@@ -913,7 +1109,7 @@ module.exports = function (SerialPort) {
   }
 
   modem.getSimInbox = (callback, timeout = 15000) => {
-    if (callback == undefined) {
+    if (typeof callback !== 'function') {
       return new Promise((resolve, reject) => {
         modem.getSimInbox((result, error) => {
           if (error) {
@@ -924,9 +1120,10 @@ module.exports = function (SerialPort) {
         }, timeout)
       })
     }
-    const item = modem.executeCommand((modem.modemMode == 0 ? `AT+CMGL=4` : `AT+CMGL="ALL"`), (result, error) => {
+    const item = modem.executeCommand((modem.modemMode === 0 ? `AT+CMGL=4` : `AT+CMGL="ALL"`), (result, error) => {
       callback(result, error)
     }, false, timeout)
+
     let resultData;
     item.logic = (newpart) => {
       let regx = /[0-9A-Fa-f]{15}/g
@@ -937,7 +1134,7 @@ module.exports = function (SerialPort) {
           data: []
         }
       }
-      if (newpart.indexOf('+CMGL:') > -1) {
+      if (newpart.includes('+CMGL:')) {
         resultData.data.push({
           index: parseInt(newpart.split(',')[0].replace('+CMGL: ', ''), 10)
         })
@@ -946,17 +1143,17 @@ module.exports = function (SerialPort) {
         let messageIndex = resultData.data[resultData.data.length - 1].index
         let message = self.processMessage(newMessage, messageIndex)
         resultData.data[resultData.data.length - 1] = message
-      } else if ((newpart == ">" || newpart == 'OK') && resultData) {
+      } else if ((newpart === '>' || newpart === 'OK') && resultData) {
         resultData.data = self.arrangeMessages(resultData.data)
         return {
           resultData,
           returnResult: true,
         }
-      } else if (newpart == 'ERROR' || newpart.indexOf('ERROR') > -1) {
+      } else if (newpart.includes('ERROR')) {
         resultData = {
           status: 'ERROR',
           request: 'getSimInbox',
-          data: 'Cannot Get Sim Inbox'
+          data: `Cannot Get Sim Inbox ${newpart}`
         }
         return {
           resultData,
@@ -967,7 +1164,7 @@ module.exports = function (SerialPort) {
   }
 
   modem.deleteMessage = (message, callback, timeout = 10000) => {
-    if (callback == undefined) {
+    if (typeof callback !== 'function') {
       return new Promise((resolve, reject) => {
         modem.deleteMessage(message, (result, error) => {
           if (error) {
@@ -978,7 +1175,7 @@ module.exports = function (SerialPort) {
         }, timeout)
       })
     }
-    if (modem.enableConcatenation == true && message.udhs) {
+    if (modem.enableConcatenation && message.udhs) {
       let indexes = message.udhs.map(a => a.index).sort((a, b) => { return b - a })
       const responses = {
         deleted: [],
@@ -1016,7 +1213,7 @@ module.exports = function (SerialPort) {
   }
 
   modem.enableCLIP = (callback, timeout = 1000) => {
-    if (callback == undefined) {
+    if (typeof callback !== 'function') {
       return new Promise((resolve, reject) => {
         modem.enableCLIP((result, error) => {
           if (error) {
@@ -1031,7 +1228,7 @@ module.exports = function (SerialPort) {
       callback(result, error)
     }, false, timeout)
     item.logic = (newpart) => {
-      if (newpart == ">" || newpart == 'OK') {
+      if (newpart === '>' || newpart === 'OK') {
         return {
           resultData: {
             status: 'success',
@@ -1040,12 +1237,50 @@ module.exports = function (SerialPort) {
           },
           returnResult: true
         }
-      } else if (newpart == 'ERROR') {
+      } else if (newpart.includes('ERROR')) {
         return {
           resultData: {
             status: 'ERROR',
             request: 'enableCLIP',
-            data: 'Error on enabling CLIP'
+            data: `Error on enabling CLIP ${newpart}`
+          },
+          returnResult: true
+        }
+      }
+    }
+  }
+
+  modem.enableCNMI = (callback, timeout = 1000) => {
+    if (typeof callback !== 'function') {
+      return new Promise((resolve, reject) => {
+        modem.enableCNMI((result, error) => {
+          if (error) {
+            reject(error)
+          } else {
+            resolve(result)
+          }
+        }, timeout)
+      })
+    }
+    const item = modem.executeCommand(`AT+CNMI=1,1,0,0,0`, (result, error) => {
+      callback(result, error)
+    }, false, timeout)
+    item.logic = (newpart) => {
+      if (newpart === '>' || newpart === 'OK') {
+        return {
+          resultData: {
+            status: 'success',
+            request: 'enableCNMI',
+            data: 'OK'
+          },
+          returnResult: true
+        }
+      } else if (newpart.includes('ERROR')) {
+        return {
+          resultData: {
+            status: 'ERROR',
+            request: 'enableCNMI',
+            data: `Error on enabling CNMI ${newpart}`
           },
           returnResult: true
         }
@@ -1054,7 +1289,7 @@ module.exports = function (SerialPort) {
   }
 
   modem.hangupCall = (callback, timeout = 1000) => {
-    if (callback == undefined) {
+    if (typeof callback !== 'function') {
       return new Promise((resolve, reject) => {
         modem.hangupCall((result, error) => {
           if (error) {
@@ -1070,7 +1305,7 @@ module.exports = function (SerialPort) {
     }, false, timeout)
     item.logic = (newpart) => {
       // console.log(`logic for command : ${item.command} with newpart : ${newpart}`)
-      if ((newpart == ">" || newpart == 'OK')) {
+      if ((newpart === '>' || newpart === 'OK')) {
         return {
           resultData: {
             status: 'success',
@@ -1079,12 +1314,12 @@ module.exports = function (SerialPort) {
           },
           returnResult: true,
         }
-      } else if (newpart == 'ERROR') {
+      } else if (newpart.includes('ERROR')) {
         return {
           resultData: {
             status: 'fail',
             request: 'hangupCall',
-            data: 'Cannot hangup call'
+            data: `Cannot hangup call ${newpart}`
           },
           returnResult: true,
         }
@@ -1119,7 +1354,7 @@ module.exports = function (SerialPort) {
   }
 
   self.arrangeMessages = messageResult => {
-    if (modem.enableConcatenation == true) {
+    if (modem.enableConcatenation) {
       let newMessageResult = []
       messageResult.forEach((message, index) => {
         if (message.udh) {
@@ -1135,7 +1370,7 @@ module.exports = function (SerialPort) {
   }
 
   self.processConcatenatedMessage = (newMessageResult, message) => {
-    let target = newMessageResult.find(a => a.udh && a.udh.referenceNumber == message.udh.referenceNumber)
+    let target = newMessageResult.find(a => a.udh && a.udh.referenceNumber === message.udh.referenceNumber)
     if (target) {
       target.udhs.push({
         index: message.index,

--- a/lib/functions/modem.js
+++ b/lib/functions/modem.js
@@ -159,7 +159,17 @@ module.exports = function (SerialPort) {
       if ((newpart === '>' || newpart === 'OK') && resultData) {
         return {
           resultData,
-          returnResult: true,
+          returnResult: true
+        }
+      }
+      else if (newpart.includes('ERROR') || ((newpart === '>' || newpart === 'OK') && !resultData)) {
+        return {
+          resultData: {
+            status: 'ERROR',
+            request: 'readSMSById',
+            data: `Cannot read Message ${newpart}`
+          },
+          returnResult: true
         }
       }
     }
@@ -192,7 +202,7 @@ module.exports = function (SerialPort) {
       if (resultData) {
         return {
           resultData,
-          returnResult: true,
+          returnResult: true
         }
       }
     }
@@ -221,7 +231,7 @@ module.exports = function (SerialPort) {
               request: 'initializeModem',
               data: `Cannot Get Modem Initialized ${newpart}`
             },
-            returnResult: true,
+            returnResult: true
           }
         }
       }
@@ -238,7 +248,7 @@ module.exports = function (SerialPort) {
                 request: 'modemInitialized',
                 data: 'Modem Successfully Initialized'
               },
-              returnResult: true,
+              returnResult: true
             }
           } else if (newpart.includes('ERROR')) {
             return {
@@ -247,7 +257,7 @@ module.exports = function (SerialPort) {
                 request: 'initializeModem',
                 data: `Cannot Get Modem Initialized ${newpart}`
               },
-              returnResult: true,
+              returnResult: true
             }
           }
         }
@@ -319,7 +329,7 @@ module.exports = function (SerialPort) {
             request: 'modemInitialized',
             data: 'Modem Successfully Initialized'
           },
-          returnResult: true,
+          returnResult: true
         }
       }else if (newpart.includes('ERROR')) {
         return {
@@ -328,7 +338,7 @@ module.exports = function (SerialPort) {
             request: 'initializeModem',
             data: `Cannot Get Modem Initialized ${newpart}`
           },
-          returnResult: true,
+          returnResult: true
         }
       }
     }
@@ -388,7 +398,7 @@ module.exports = function (SerialPort) {
         if ((newpart === '>' || newpart === 'OK') && resultData) {
           return {
             resultData,
-            returnResult: true,
+            returnResult: true
           }
         }
       }
@@ -666,7 +676,7 @@ module.exports = function (SerialPort) {
       if ((newpart === '>' || newpart === '> ' || newpart === 'OK') && resultData) {
         return {
           resultData,
-          returnResult: true,
+          returnResult: true
         }
       } else if (newpart.includes('ERROR')) {
         return {
@@ -675,7 +685,7 @@ module.exports = function (SerialPort) {
             request: 'getModemSerial',
             data: `Cannot Get Modem Serial Number ${newpart}`
           },
-          returnResult: true,
+          returnResult: true
         }
       }
     }
@@ -714,7 +724,7 @@ module.exports = function (SerialPort) {
       if ((newpart === '>' || newpart === '> ' || newpart === 'OK') && resultData) {
         return {
           resultData,
-          returnResult: true,
+          returnResult: true
         }
       } else if (newpart.includes('ERROR')) {
         return {
@@ -723,7 +733,7 @@ module.exports = function (SerialPort) {
             request: 'getNetworkSignal',
             data: `Cannot Get Signal ${newpart}`
           },
-          returnResult: true,
+          returnResult: true
         }
       }
     }
@@ -749,7 +759,7 @@ module.exports = function (SerialPort) {
     }
     if (!modem.isOpened) {
       modem.emit('close')
-      return
+      return {}
     }
 
     let item = new EventEmitter()
@@ -1030,7 +1040,7 @@ module.exports = function (SerialPort) {
             request: 'selectPhonebookStorage',
             data: newpart
           },
-          returnResult: true,
+          returnResult: true
         }
       } else if (newpart.includes('ERROR')) {
         return {
@@ -1039,7 +1049,7 @@ module.exports = function (SerialPort) {
             request: 'selectPhonebookStorage',
             data: `Error on setting phonebook storage ${newpart}`
           },
-          returnResult: true,
+          returnResult: true
         }
       }
     }
@@ -1069,7 +1079,7 @@ module.exports = function (SerialPort) {
             request: 'writeToPhonebook',
             data: newpart
           },
-          returnResult: true,
+          returnResult: true
         }
       } else if (newpart.includes('ERROR')) {
         return {
@@ -1078,7 +1088,7 @@ module.exports = function (SerialPort) {
             request: 'writeToPhonebook',
             data: `Cannot Write To Phonebook ${newpart}`
           },
-          returnResult: true,
+          returnResult: true
         }
       }
     }
@@ -1147,7 +1157,7 @@ module.exports = function (SerialPort) {
         resultData.data = self.arrangeMessages(resultData.data)
         return {
           resultData,
-          returnResult: true,
+          returnResult: true
         }
       } else if (newpart.includes('ERROR')) {
         resultData = {
@@ -1157,7 +1167,7 @@ module.exports = function (SerialPort) {
         }
         return {
           resultData,
-          returnResult: true,
+          returnResult: true
         }
       }
     }
@@ -1312,7 +1322,7 @@ module.exports = function (SerialPort) {
             request: 'hangupCall',
             data: newpart,
           },
-          returnResult: true,
+          returnResult: true
         }
       } else if (newpart.includes('ERROR')) {
         return {
@@ -1321,7 +1331,7 @@ module.exports = function (SerialPort) {
             request: 'hangupCall',
             data: `Cannot hangup call ${newpart}`
           },
-          returnResult: true,
+          returnResult: true
         }
       }
     }

--- a/lib/functions/modem.js
+++ b/lib/functions/modem.js
@@ -1262,7 +1262,7 @@ module.exports = function (SerialPort) {
         }, timeout)
       })
     }
-    const item = modem.executeCommand(`AT+CNMI=1,1,0,0,0`, (result, error) => {
+    const item = modem.executeCommand(`AT+CNMI=2,1,0,2,0`, (result, error) => {
       callback(result, error)
     }, false, timeout)
     item.logic = (newpart) => {

--- a/lib/functions/modem.js
+++ b/lib/functions/modem.js
@@ -191,15 +191,13 @@ module.exports = function (SerialPort) {
     const item = modem.executeCommand(`AT+CPMS="SM"`, (result, error) => {
       callback(result, error)
     }, priority)
+
+    let resultData;
     item.logic = (newpart) => {
-      let resultData;
       if (newpart.trim().startsWith('+CPMS:')) {
-        modem.parseSimCardResponse(newpart, result => {
-          resultData = result
-        })
+          resultData = modem.parseSimCardResponse(newpart)
       }
-      //(newpart === '>' || newpart === 'OK') &&
-      if (resultData) {
+      if ((newpart === '>' || newpart === 'OK') && resultData) {
         return {
           resultData,
           returnResult: true
@@ -281,7 +279,7 @@ module.exports = function (SerialPort) {
       })
     }
     if (priority == null) priority = false
-    modem.checkModem((resultCheck, error) => {
+    modem.resetModem((resultCheck, error) => {
       if (!error) {
         modem.checkPINRequired((result, error) => {
           if (!error && result.data.pinNeeded && modem.pin.length) {
@@ -304,10 +302,10 @@ module.exports = function (SerialPort) {
     });
   }
 
-  modem.checkModem = function (callback, priority, timeout) {
+  modem.resetModem = function (callback, priority, timeout) {
     if (typeof callback !== 'function') {
       return new Promise((resolve, reject) => {
-        modem.checkModem((result, error) => {
+        modem.resetModem((result, error) => {
           if (error) {
             reject(error)
           } else {
@@ -344,7 +342,47 @@ module.exports = function (SerialPort) {
     }
   }
 
-  modem.setModemMode = function (callback, priority, timeout, mode) {
+    modem.checkModem = function (callback, priority, timeout) {
+        if (typeof callback !== 'function') {
+            return new Promise((resolve, reject) => {
+                modem.checkModem((result, error) => {
+                    if (error) {
+                        reject(error)
+                    } else {
+                        resolve(result)
+                    }
+                }, priority, timeout)
+            })
+        }
+        if (priority == null) priority = false
+        // is the modem Ready?
+        const item = modem.executeCommand('AT', (resultInit, error) => {
+            callback(resultInit, error)
+        }, false, timeout || 30000)
+        item.logic = (newpart) => {
+            if (newpart === '>' || newpart === '> ' || newpart === 'OK') {
+                return {
+                    resultData: {
+                        status: 'success',
+                        request: 'checkModem',
+                        data: 'Modem Available'
+                    },
+                    returnResult: true
+                }
+            }else if (newpart.includes('ERROR')) {
+                return {
+                    resultData: {
+                        status: 'ERROR',
+                        request: 'checkModem',
+                        data: `Cannot Communicate with Modem ${newpart}`
+                    },
+                    returnResult: true
+                }
+            }
+        }
+    }
+
+    modem.setModemMode = function (callback, priority, timeout, mode) {
     if(callback !== undefined && typeof callback !== 'function') {
       return modem.setModemMode(undefined, callback, priority, timeout, mode)
     }
@@ -948,20 +986,26 @@ module.exports = function (SerialPort) {
     simCardCheck.used = parseInt(newpart[0])
     simCardCheck.total = parseInt(newpart[1])
     if (simCardCheck.used === simCardCheck.total) {
-      modem.emit('onMemoryFull', {
-        status: 'Memory Full',
-        data: {
-          used: simCardCheck.used,
-          total: simCardCheck.total
-        }
+      setImmediate(() => {
+        modem.emit('onMemoryFull', {
+          status: 'Memory Full',
+          data: {
+            used: simCardCheck.used,
+            total: simCardCheck.total
+          }
+        })
       })
     }
+    const result = {
+      status: 'success',
+      request: 'checkSimMemory',
+      data: simCardCheck
+    };
     if (callback) {
-      callback({
-        status: 'success',
-        request: 'checkSimMemory',
-        data: simCardCheck
-      })
+      callback(result)
+    }
+    else {
+      return result
     }
   }
 


### PR DESCRIPTION
* reworked modem initialization that order of commands is correct after PIN
* add support to check and provide a PIN
* added an optional logger via options; currently supports "debug" logging
* added debug logging for Writes and Received commands
* added a custom initialization command (some modes need that) which is then send after PIN check
* added options.incomingSMSIndication flag to officially send enable command for push info on new messages; default is true for backward compatibility
* changed double-quotes into single quotes in strings
* send AT+CMEE=1 (enhanced error infos) and CREG=2 (enhanced details on CREG command)
* make some checks more generic
* add error details to the error messages
* some code and logic error from last refactoring (was not really working on some places?) are fixed
* add signalStrength property with calculated db value on Signal-Strength method
* add proper error handling when accessing empty SMS slots
* executeCommand always need to return an object, else all the "item.logic" calls will end in an exception
* removed unneeded comma in some objects
* fix checkSimMemory
* rename introduced "checkModem" to "resetModem" because ATZ will also reset to factory defaults!
* add a new checkModem to only send AT to check communication with device
* parse SimInbox response synchronous to prevent pot. async problems (in fact now method can do both, the event is emitted async)

* fixes #18, #19 
* partially #20