### PR TITLE
change processing logic!

### DIFF
--- a/lib/functions/modem.js
+++ b/lib/functions/modem.js
@@ -192,14 +192,10 @@ module.exports = function (SerialPort) {
       callback(result, error)
     }, priority)
 
-    let resultData;
     item.logic = (newpart) => {
       if (newpart.trim().startsWith('+CPMS:')) {
-        resultData = modem.parseSimCardResponse(newpart)
-      }
-      if ((newpart === '>' || newpart === 'OK') && resultData) {
         return {
-          resultData,
+          resultData: modem.parseSimCardResponse(newpart),
           returnResult: true
         }
       }
@@ -213,14 +209,14 @@ module.exports = function (SerialPort) {
         // we do not need the callback
       }, false, timeout || 30000)
       item.logic = (newpart) => {
-        if (newpart === '>' || newpart === '> ' || newpart === 'OK') {
+        if (newpart.trim() === '>' || newpart === 'OK') {
           return {
             resultData: {
               status: 'success',
               request: 'modemInitialized',
               data: 'Modem Successfully Initialized'
             },
-            returnResult: true,
+            returnResult: true
           }
         } else if (newpart.includes('ERROR')) {
           return {
@@ -239,7 +235,7 @@ module.exports = function (SerialPort) {
           // we do not need the callback
         }, false, timeout || 30000)
         item.logic = (newpart) => {
-          if (newpart === '>' || newpart === '> ' || newpart === 'OK') {
+          if (newpart.trim() === '>' || newpart === 'OK') {
             return {
               resultData: {
                 status: 'success',
@@ -281,21 +277,27 @@ module.exports = function (SerialPort) {
     if (priority == null) priority = false
     modem.resetModem((resultCheck, error) => {
       if (!error) {
-        modem.checkPINRequired((result, error) => {
-          if (!error && result.data.pinNeeded && modem.pin.length) {
-            modem.providePIN(modem.pin, (result, error) => {
-              if (!error) {
-                sendAdditionalCommands()
+        modem.enableEcho((resultCheck, error) => {
+          if (!error) {
+            modem.checkPINRequired((result, error) => {
+              if (!error && result.data.pinNeeded && modem.pin.length) {
+                modem.providePIN(modem.pin, (result, error) => {
+                  if (!error) {
+                    sendAdditionalCommands()
+                  }
+                  callback(resultCheck, error)
+                })
+              } else {
+                if (!error) {
+                  sendAdditionalCommands()
+                }
+                callback(resultCheck, error)
               }
-              callback(resultCheck, error)
             })
           } else {
-            if (!error) {
-              sendAdditionalCommands()
-            }
             callback(resultCheck, error)
           }
-        })
+        });
       } else {
         callback(resultCheck, error)
       }
@@ -318,7 +320,7 @@ module.exports = function (SerialPort) {
     // is the modem Ready?
     const item = modem.executeCommand('ATZ', (resultInit, error) => {
       callback(resultInit, error)
-    }, false, timeout || 30000)
+    }, false, timeout || 30000, undefined, undefined, undefined, true) // auto activate it if no Echo is active
     item.logic = (newpart) => {
       if (newpart === '>' || newpart === '> ' || newpart === 'OK') {
         return {
@@ -335,6 +337,46 @@ module.exports = function (SerialPort) {
             status: 'ERROR',
             request: 'initializeModem',
             data: `Cannot Get Modem Initialized ${newpart}`
+          },
+          returnResult: true
+        }
+      }
+    }
+  }
+
+  modem.enableEcho = function (callback, priority, timeout) {
+    if (typeof callback !== 'function') {
+      return new Promise((resolve, reject) => {
+        modem.enableEcho((result, error) => {
+          if (error) {
+            reject(error)
+          } else {
+            resolve(result)
+          }
+        }, priority, timeout)
+      })
+    }
+    if (priority == null) priority = false
+    // is the modem Ready?
+    const item = modem.executeCommand('ATE1', (resultInit, error) => {
+      callback(resultInit, error)
+    }, false, timeout || 30000, undefined, undefined, undefined, true) // auto activate it if no Echo is active
+    item.logic = (newpart) => {
+      if (newpart === '>' || newpart === '> ' || newpart === 'OK') {
+        return {
+          resultData: {
+            status: 'success',
+            request: 'enableEcho',
+            data: 'Modem Echo Successfully Activated'
+          },
+          returnResult: true
+        }
+      } else if (newpart.includes('ERROR')) {
+        return {
+          resultData: {
+            status: 'ERROR',
+            request: 'initializeModem',
+            data: `Cannot Activate Modem Echo ${newpart}`
           },
           returnResult: true
         }
@@ -509,7 +551,7 @@ module.exports = function (SerialPort) {
               modem.emit(channel, result)
               callback(result)
             }
-          }, false, 30000, messageID, message, number)
+          }, false, 30000, messageID, message, number, true)
         }
         // if it is called with promise (the promise callback has 2 args)
         // it is better not to callback until the message is sent or failed, 
@@ -561,18 +603,16 @@ module.exports = function (SerialPort) {
     let resultData
     item.logic = (newpart) => {
       if (newpart.startsWith('+CPIN: ')) {
-        resultData = {
-          status: 'success',
-          request: 'checkPINRequired',
-          data: { pinNeeded: !newpart.includes('READY') }
-        }
-      }
-      if (resultData) {
         return {
-          resultData,
+          resultData: {
+            status: 'success',
+            request: 'checkPINRequired',
+            data: { pinNeeded: !newpart.includes('READY') }
+          },
           returnResult: true
         }
-      } else if (newpart.includes('ERROR')) {
+      }
+      if (newpart.includes('ERROR')) {
         return {
           resultData: {
             status: 'Error',
@@ -705,18 +745,16 @@ module.exports = function (SerialPort) {
     item.logic = (newpart) => {
       let isSerial = /^\d+$/.test(newpart)
       if (isSerial) {
-        resultData = {
-          status: 'success',
-          request: 'getModemSerial',
-          data: { 'modemSerial': newpart }
-        }
-      }
-      if ((newpart === '>' || newpart === '> ' || newpart === 'OK') && resultData) {
         return {
-          resultData,
+          resultData: {
+            status: 'success',
+            request: 'getModemSerial',
+            data: { 'modemSerial': newpart }
+          },
           returnResult: true
         }
-      } else if (newpart.includes('ERROR')) {
+      }
+      else if (newpart.includes('ERROR')) {
         return {
           resultData: {
             status: 'ERROR',
@@ -751,21 +789,19 @@ module.exports = function (SerialPort) {
       if (newpart.startsWith('+CSQ:')) {
         let signal = newpart.split(' ')
         signal = signal[1].split(',')
-        resultData = {
-          status: 'success',
-          request: 'getNetworkSignal',
-          data: {
-            'signalQuality': signal[0],
-            'signalStrength': signal[0] !== 99 ? (113 - signal[0] * 2) : undefined
-          }
-        }
-      }
-      if ((newpart === '>' || newpart === '> ' || newpart === 'OK') && resultData) {
         return {
-          resultData,
+          resultData:{
+            status: 'success',
+            request: 'getNetworkSignal',
+            data: {
+              'signalQuality': signal[0],
+              'signalStrength': signal[0] !== 99 ? (113 - signal[0] * 2) : undefined
+            }
+          },
           returnResult: true
         }
-      } else if (newpart.includes('ERROR')) {
+      }
+      if (newpart.includes('ERROR')) {
         return {
           resultData: {
             status: 'ERROR',
@@ -784,7 +820,7 @@ module.exports = function (SerialPort) {
     modem.queue.shift() //Remove current item from queue.
   }
 
-  modem.executeCommand = (command, callback, priority, timeout, messageID, message, recipient) => {
+  modem.executeCommand = (command, callback, priority, timeout, messageID, message, recipient, activateProcessing) => {
     if (typeof callback !== 'function') {
       return new Promise((resolve, reject) => {
         modem.executeCommand(command, (result, error) => {
@@ -816,6 +852,7 @@ module.exports = function (SerialPort) {
     item.on('timeout', () => {
       callback(undefined, new Error(`timeout: \n${JSON.stringify(item)}`))
     })
+    item.inProgress = activateProcessing;
     // item.on('start', ()=>{
     //   console.log('started')
     // })
@@ -903,6 +940,10 @@ module.exports = function (SerialPort) {
         })
 
         if (modem.queue.length && modem.queue[0]) {
+          if (modem.queue[0].command.trim() === newpart.trim()) { // Echo of command received, only process if active
+            modem.queue[0].inProgress = true;
+            modem.logger.debug('Activate Message Processing for: ' + newpart)
+          }
           if ((modem.queue[0].status === 'sendSMS')) { // If SMS is currently Sending Emit currently sending SMS
             modem.emit('onSendingMessage', {
               status: 'Sending SMS',
@@ -943,23 +984,25 @@ module.exports = function (SerialPort) {
               returnResult = true
             }
           } else { // let's check if it has a logic function
-            if (modem.queue[0].logic) {
+            if (modem.queue[0].logic && modem.queue[0].inProgress) {
               const logicResult = modem.queue[0].logic(newpart);
               if (logicResult) {
                 resultData = logicResult.resultData
                 returnResult = logicResult.returnResult
               }
             } else {
-              console.log(`I could not do any thing :( ${newpart}`)
+              modem.logger.debug(`Ignore Data: ${newpart}`)
             }
           }
           let callback
-          if (returnResult) { // Expected Result was ok or with error call back function that asked for the data or emit to listener, Execute next Command if any or Execute Next Command if TIME Out and modem did not respond
+          if (returnResult && modem.queue[0].inProgress) { // Expected Result was ok or with error call back function that asked for the data or emit to listener, Execute next Command if any or Execute Next Command if TIME Out and modem did not respond
             returnResult = false
             if (modem.queue[0] && modem.queue[0].callback) {
               callback = modem.queue[0].callback
+              modem.logger.debug('Call callback for: ' + modem.queue[0].command)
             } else {
               callback = null
+              modem.logger.debug('No callback for: ' + modem.queue[0].command)
             }
 
             modem.queue[0].end_time = new Date()
@@ -967,7 +1010,7 @@ module.exports = function (SerialPort) {
             modem.release()
 
             if (callback) {
-              callback(resultData)
+              setImmediate(callback, resultData) // call callback async
             }
             resultData = null
             modem.executeNext()
@@ -1031,22 +1074,20 @@ module.exports = function (SerialPort) {
       if (newpart.startsWith('+CNUM')) {
         let splitResult = newpart.split(',')
         if (splitResult.length > 0 && splitResult[1]) {
-          resultData = {
-            status: 'success',
-            request: 'getOwnNumber',
-            data: {
-              name: /"(.*?)"/g.exec(splitResult[0])[1],
-              number: /"(.*?)"/g.exec(splitResult[1])[1]
-            }
+          return {
+            resultData: {
+              status: 'success',
+              request: 'getOwnNumber',
+              data: {
+                name: /"(.*?)"/g.exec(splitResult[0])[1],
+                number: /"(.*?)"/g.exec(splitResult[1])[1]
+              }
+            },
+            returnResult: true
           }
         } else {
           // TODO what will happen here?
           newpart === 'ERROR'
-        }
-      } else if ((newpart === '>' || newpart === 'OK') && resultData) {
-        return {
-          resultData,
-          returnResult: true
         }
       } else if (newpart.includes('ERROR')) {
         return {


### PR DESCRIPTION
- it now uses command ECHOs (will be activated at the beginning if not enabled) to detedt the "start" of a certain command and only then the entry-specific logic is checked
- executeCommand got an extra parameter to "pre-activate" special entries to send (like Data elements) so that they are handled correctly because they will not get echoed
- Added some additional debug logging for now to better understand the logic processing and callbacks. Could be removed later

Main Effect is that "one line response commands" can not handled as done as soon as The correct line was received and no logic to wait for "OK" or such is needed. This will be ignored

@zabsalahid @karianpour  Please review