### PR TITLE
Update modem.js

### DIFF
--- a/lib/functions/modem.js
+++ b/lib/functions/modem.js
@@ -291,28 +291,28 @@ module.exports = function (SerialPort) {
         modem.enableEcho((result, error) => {
           if (!error) {
             modem.checkPINRequired((result, error) => {
-              if (!error && result.data.pinNeeded && modem.pin.length) {
+              if (!error && result.data && result.data.pinNeeded && modem.pin.length) {
                 modem.providePIN(modem.pin, (result, error) => {
                   if (!error) {
                     sendAdditionalCommands()
                   }
                   callback(resultCheck, error)
-                })
+                }, priority, timeout)
               } else {
                 if (!error) {
                   sendAdditionalCommands()
                 }
                 callback(resultCheck, error)
               }
-            })
+            }, priority, timeout)
           } else {
             callback(resultCheck, error)
           }
-        });
+        }, priority, timeout);
       } else {
         callback(resultCheck, error)
       }
-    });
+    }, priority, timeout);
   }
 
   modem.resetModem = function (callback, priority, timeout) {


### PR DESCRIPTION
if (!error && result.data && result.data.pinNeeded && modem.pin.length) {
result.data is undefined when result.data.message === "ERROR"

, priority, timeout)
added to all calls in initializeModem. Without it, you can't specify a timeout for those calls and init is always 30 seconds...