### PR TITLE
changed serial port API to support promise based API

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17,13 +17,10 @@ const SerialPortGSM = {
         })
       })
     }
-    SerialPort.list((error, results) => {
-      if (error) {
-        callback(error)
-      } else {
-        callback(null, results)
-      }
-    })
+    SerialPort
+      .list()
+      .then(results=>callback(null, results))
+      .catch(error=>callback(error))
   },
 
   Modem: function (params) {


### PR DESCRIPTION
Since the serialport library does not support callbacks in the list function, it causes the application to throw an error. I've replaced the list function to support the new promise based API