### PR TITLE
Add compatibility with A6 modules

### DIFF
--- a/lib/functions/modem.js
+++ b/lib/functions/modem.js
@@ -613,7 +613,7 @@ module.exports = function (SerialPort) {
 
     let resultData
     item.logic = (newpart) => {
-      if (newpart.startsWith('+CPIN: ')) {
+      if (newpart.startsWith('+CPIN:')) {
         return {
           resultData: {
             status: 'success',


### PR DESCRIPTION
Change expected output of "AT+CPIN?"
Before:  "+CPIN: "
Now: "+CPIN:"

This adds compatibility with Ai-Thinker A6 modules.