### PR TITLE
getSimInbox: add message status

### DIFF
--- a/lib/functions/modem.js
+++ b/lib/functions/modem.js
@@ -1277,7 +1277,7 @@ module.exports = function (SerialPort) {
       if (newpart.includes('+CMGL:')) {
         resultData.data.push({
           index: parseInt(newpart.split(',')[0].replace('+CMGL: ', ''), 10),
-          msgStatus: parseInt(newpart.split(',')[1], 10)
+          msgStatus: newpart.split(',')[1]
         })
       } else if (regx.test(newpart)) {
         let newMessage = pdu.parse(newpart)

--- a/lib/functions/modem.js
+++ b/lib/functions/modem.js
@@ -1276,12 +1276,14 @@ module.exports = function (SerialPort) {
       }
       if (newpart.includes('+CMGL:')) {
         resultData.data.push({
-          index: parseInt(newpart.split(',')[0].replace('+CMGL: ', ''), 10)
+          index: parseInt(newpart.split(',')[0].replace('+CMGL: ', ''), 10),
+          msgStatus: parseInt(newpart.split(',')[1], 10)
         })
       } else if (regx.test(newpart)) {
         let newMessage = pdu.parse(newpart)
         let messageIndex = resultData.data[resultData.data.length - 1].index
-        let message = self.processMessage(newMessage, messageIndex)
+        let messageStatus = resultData.data[resultData.data.length - 1].msgStatus
+        let message = self.processMessage(newMessage, messageIndex, messageStatus)
         resultData.data[resultData.data.length - 1] = message
       } else if ((newpart === '>' || newpart === 'OK') && resultData) {
         resultData.data = self.arrangeMessages(resultData.data)
@@ -1467,11 +1469,12 @@ module.exports = function (SerialPort) {
     }
   }
 
-  self.processMessage = (message, messageIndex) => {
+  self.processMessage = (message, messageIndex, messageStatus) => {
     let newMessage = {
       sender: message.getAddress().getPhone() || null,
       message: message.getData().getText() || null,
       index: messageIndex,
+      msgStatus: messageStatus,
       dateTimeSent: message.getScts() ? new Date(message.getScts().getIsoString()) : null || null,
       header: {
         encoding: self.getEncoding(message.getDcs()._dataEncoding) || null,


### PR DESCRIPTION
Includes the message status (0 - 4, unread/read) in the message object. Is useful to separate unread from read messages when reading SIM inbox.